### PR TITLE
tried to fix height, added container to boat index

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -1,5 +1,5 @@
 Specific CSS for your home-page
-.container{
+.container {
   width: 80vw;
 }
 

--- a/app/views/boats/index.html.erb
+++ b/app/views/boats/index.html.erb
@@ -1,3 +1,4 @@
+<div class="container">
   <div class="row">
     <div class="home-cards col-xs-12">
       <% @boats.each do |boat| %>
@@ -19,3 +20,4 @@
       <% end %>
     </div>
   </div>
+</div>


### PR DESCRIPTION
j'ai essayé de régler le problème de hauteur des pages mais j'ai pas réussi ! 
on peut pas faire => "height: 100vh - 80px - 60px;" 
et après je me suis rendu compte que notre "container" qu'on met sur les pages est le container bootstrap, pas notre container (défini dans le fichier _home.cscc).
donc à regarder.... 

par contre, j'ai rajouté un container sur la page boats index. 
